### PR TITLE
HP Bugfixes regarding level transition, death and potions

### DIFF
--- a/Autoloads/SavedData.gd
+++ b/Autoloads/SavedData.gd
@@ -2,7 +2,9 @@ extends Node
 
 var num_floor: int = 0
 
+const MaxHP = 4
 var hp: int = 4
+
 var weapons: Array = []
 var equipped_weapon_index: int = 0
 

--- a/Characters/Player/PlayerFSM.gd
+++ b/Characters/Player/PlayerFSM.gd
@@ -44,3 +44,6 @@ func _enter_state(_previous_state: int, new_state: int) -> void:
 		states.dead:
 			animation_player.play("dead")
 			parent.cancel_attack()
+			SavedData.hp = SavedData.MaxHP
+			SavedData.num_floor = 0
+		

--- a/Items/HealthPotion.gd
+++ b/Items/HealthPotion.gd
@@ -7,6 +7,7 @@ onready var tween: Tween = get_node("Tween")
 func _on_HealthPotion_body_entered(player: KinematicBody2D) -> void:
 	collision_shape.set_deferred("disabled", true)
 	player.hp += 1
+	SavedData.hp += 1
 	var __ = tween.interpolate_property(self, "modulate", Color(1, 1, 1, 1), Color(1, 1, 1, 0), 0.6, Tween.TRANS_SINE, Tween.EASE_IN)
 	assert(__)
 	__ = tween.interpolate_property(self, "position", position, position + Vector2.UP * 16, 0.6, Tween.TRANS_SINE, Tween.EASE_IN)


### PR DESCRIPTION
SavedData.gd - Added a way to restore original Max HP after player dies
PlayerFSM.gd - A way to restore initial state for HP after death
HealthPotion.gd - Makes potions persistent between levels